### PR TITLE
fix #37 Directory name get's truncated if name contains a period "." 

### DIFF
--- a/src/QlrBrowser/ui/dockwidget.py
+++ b/src/QlrBrowser/ui/dockwidget.py
@@ -250,6 +250,10 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
 
     def updateDisplay(self):
         name = self.fileitem.displayname
+        # labels containing dots get truncated, here a little workaround
+        if self.fileitem.isdir:
+            name = os.path.split(self.fileitem.fullpath)[-1]
+
         font = self.font(0)
         font.setBold(False)
         if self.fileitem.isdir:


### PR DESCRIPTION
This should fix issue #37 
